### PR TITLE
creating output file with some access rights

### DIFF
--- a/cleaner.c
+++ b/cleaner.c
@@ -734,7 +734,7 @@ int run(char* fnin, char* fnout)
     close(fin);
 
     // open output file
-    int fout = open(fnout, O_TRUNC | O_CREAT | O_WRONLY);
+    int fout = open(fnout, O_TRUNC | O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if (fout < 0)
         return fprintf(stderr, "Could not open file `%s` for writing\n", fnout);
 


### PR DESCRIPTION
So I've been wondering why cleaner only works with one argument on my Ubuntu, and it turned out that it did work with 2 arguments - just created output file that couldn't be accessed...

    ---------- 1 vb vb   393 kvě  6 16:03 t.wasm

Reading `man open`, the third argument is required when creating a file.